### PR TITLE
Ensure httpClient gets the transport we create

### DIFF
--- a/common/consul.go
+++ b/common/consul.go
@@ -60,6 +60,8 @@ func (cc *ConsulConfig) NewClient() (*ConsulClient, error) {
 		httpClient := cleanhttp.DefaultClient()
 		httpTransport := cleanhttp.DefaultTransport()
 		httpTransport.TLSClientConfig = tlsConfig
+		httpClient.Transport = httpTransport
+
 		// set client
 		c.HttpClient = httpClient
 	}


### PR DESCRIPTION
This is why my tests that previously worked started failing: a new `cleanhttp.DefaultTransport()` was created and configured but never set to the `httpClient`