### PR TITLE
Nomad job file to make this work with S3.

### DIFF
--- a/consul-backinator.nomad
+++ b/consul-backinator.nomad
@@ -1,0 +1,84 @@
+job "consul-backinator" {
+
+  datacenters = ["dc1"]
+
+
+  type = "service"
+
+
+  update {
+
+    stagger = "10s"
+
+
+    max_parallel = 1
+  }
+
+
+  group "consul-backinator" {
+
+    count = 1
+
+
+    restart {
+      # The number of attempts to run the job within the specified interval.
+      # Runs the job every hour, adjust depending on your needs.
+      
+      attempts = 1
+      interval = "1h"
+
+      # The "delay" parameter specifies the duration to wait before restarting
+      # a task after it has failed.
+      
+      delay = "1h"
+
+
+      mode = "delay"
+    }
+
+
+    ephemeral_disk {
+
+      size = 300
+    }
+
+  #task for consul-backinator
+  task "consul-backinator" {
+
+      driver = "docker"
+
+      # The "config" stanza specifies the driver configuration, which is passed
+      # directly to the driver to start the task. The details of configurations
+      # are specific to each driver, so please see specific driver
+      # documentation for more information.
+      
+      config {
+        image = "myena/consul-backinator"
+
+        args = [
+        "backup", "-file", "s3://name-of-your-bucket/backups"
+        ]
+
+      }
+
+      env {
+
+        "AWS_ACCESS_KEY_ID"     = "AWS ACCESS KEY GOES HERE"
+        "AWS_SECRET_ACCESS_KEY" = "AWS SECRET KEY GOES HERE"
+        "AWS_REGION"            = "us-east-1"
+        "CONSUL_HTTP_ADDR"      = "${NOMAD_IP_consulbackinator}:8500"
+      }
+
+      resources {
+        cpu    = 500 # 500 MHz
+        memory = 256 # 256MB
+        network {
+          mbits = 10
+          port "consulbackinator" {}
+        }
+      }
+
+
+    }
+  }
+}


### PR DESCRIPTION
After a lot of tooling around to make this work properly in Nomad, here is an out of the box nomad config file written in HCL aka Hashi-Corp Configuration Language. They like to append .nomad to these files, but you can use .hcl or another extension. This should be plug and play as long as you have S3 set up. I advise using journaling.

If you change this around a bit and run into issues, Nomad won't really return any useful errors besides a non-zero exit code, and 'nomad logs' fails to return any since the container runs so quickly. But you can scrounge up the logs on the node running the job at /var/lib/nomad/alloc/[allocation-id]/alloc/logs/consul-backinator.stderr.0