### PR TITLE
Added S3 PathStyle-Option

### DIFF
--- a/common/s3util.go
+++ b/common/s3util.go
@@ -111,6 +111,16 @@ func parseS3URI(s3uri string) (*s3Info, error) {
 		// update config
 		info.awsConfig.DisableSSL = aws.Bool(secure)
 	}
+	
+	//check for pathstyle override
+	if temps := u.Query().Get("pathstyle"); temps != "" {
+		var pathstyle bool // local bool
+		if pathstyle, err = strconv.ParseBool(temps); err != nil {
+			return nil, err
+		}
+		// update config
+		info.awsConfig.S3ForcePathStyle = aws.Bool(pathstyle)
+	}
 
 	// return populated struct
 	return info, nil


### PR DESCRIPTION
Added functionality to confige the S3-Path-Style-Option. By default the S3-clients uses the bucketname as hostname to access the S3 storage, eg. https://BUCKET.s3.provider.com/....

If the prvoider does not support this, but instead uses the format http://s3.provider.com/BUCKET/... consul-backinator was not working.

Now it is possible to set the parameter pathstyle=true in the S3-URL, and the bucket will be accessed by path and not by hostname.

Example
s3://KEY:SECRET@BUCKET/test_backup.bak?region=us-east-1&endpoint=s3.provider.com&pathstyle=true


